### PR TITLE
build: [#62] Update Grype scan action to 4.1.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -79,7 +79,7 @@ runs:
         path: "."
         severity-cutoff: high
     - name: Scan image using Grype
-      uses: anchore/scan-action@v3
+      uses: anchore/scan-action@v4.1.0
       with:
         image: ${{ steps.meta.outputs.tags }}
         only-fixed: false


### PR DESCRIPTION
This PR will update a second entry of Grype scan action to 4.1.0.