### PR TITLE
fix: [#91] Prevent bump into rate limiting by pulling TrivyDBs from AWS ECR

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,14 @@ jobs:
 
 <!-- markdownlint-disable MD013 -->
 
-| Option               | Default                              | Required | Description                                                                                                      |
-| :------------------- | :----------------------------------- | -------- | :--------------------------------------------------------------------------------------------------------------- |
-| dockle-accept-key    | 80                                   |          | Suppress certain environment variables in a docker image that are seen as secrets, but are not                   |
-| token                | ' '                                  | x        | GitHub token that is required to push an image to the registry of the project and to pull cached Trivy DB images |
-| trivy-action-db      | ghcr.io/aquasecurity/trivy-db:2      |          | Replace this with a cached image to prevent bump into pull rate limiting issues                                  |
-| trivy-action-java-db | ghcr.io/aquasecurity/trivy-java-db:1 |          | Replace this with a cached image to prevent bump into pull rate limiting issues                                  |
+| Option               | Default | Required | Description                                                                                                      |
+| :------------------- | :------ | -------- | :--------------------------------------------------------------------------------------------------------------- |
+| dockle-accept-key    | x       |          | Suppress certain environment variables in a docker image that are seen as secrets, but are not                   |
+| token                | x       | x        | GitHub token that is required to push an image to the registry of the project and to pull cached Trivy DB images |
+| trivy-action-db      | x       |          | Replace this with a cached image to prevent bump into pull rate limiting issues                                  |
+| trivy-action-java-db | x       |          | Replace this with a cached image to prevent bump into pull rate limiting issues                                  |
+
+Note: If an **x** is registered in the Default column, refer to the
+[action.yml](action.yml) for the corresponding value.
 
 <!-- markdownlint-enable MD013 -->

--- a/action.yml
+++ b/action.yml
@@ -12,13 +12,13 @@ inputs:
       incorrect. To mitigate this one has to specify the packages that are
       applicable, e.g.: `libcrypto3,libssl3`.
   trivy-action-db:
-    default: "ghcr.io/aquasecurity/trivy-db:2"
+    default: "public.ecr.aws/aquasecurity/trivy-db:2"
     description: |
       OCI repository to retrieve trivy-db from.
   trivy-action-java-db:
+    default: "public.ecr.aws/aquasecurity/trivy-java-db:1"
     description: |
       OCI repository to retrieve trivy-java-db from.
-    default: "ghcr.io/aquasecurity/trivy-java-db:1"
   token:
     description: |
       A token is required to allow the mcvs-docker-action to push the


### PR DESCRIPTION
Otherwise rate limiting issues will occur.