### PR TITLE
feat: [#96] Docker build arg support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,16 +35,14 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-<!-- markdownlint-disable MD013 -->
-
-| Option               | Default | Required | Description                                                                                                      |
-| :------------------- | :------ | -------- | :--------------------------------------------------------------------------------------------------------------- |
-| dockle-accept-key    | x       |          | Suppress certain environment variables in a docker image that are seen as secrets, but are not                   |
-| token                | x       | x        | GitHub token that is required to push an image to the registry of the project and to pull cached Trivy DB images |
-| trivy-action-db      | x       |          | Replace this with a cached image to prevent bump into pull rate limiting issues                                  |
-| trivy-action-java-db | x       |          | Replace this with a cached image to prevent bump into pull rate limiting issues                                  |
+| Option               | Default | Required |
+| :------------------- | :------ | -------- |
+| build-args           |         |          |
+| dockle-accept-key    | x       |          |
+| images               | x       |          |
+| token                | x       | x        |
+| trivy-action-db      | x       |          |
+| trivy-action-java-db | x       |          |
 
 Note: If an **x** is registered in the Default column, refer to the
 [action.yml](action.yml) for the corresponding value.
-
-<!-- markdownlint-enable MD013 -->

--- a/action.yml
+++ b/action.yml
@@ -138,10 +138,6 @@ runs:
         password: ${{ inputs.token }}
     - name: Build and push Docker image
       if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
-      uses: docker/build-push-action@v6.9.0
-      with:
-        build-args: APPLICATION=${{ inputs.build-args }}
-        context: .
-        labels: ${{ steps.meta.outputs.labels }}
-        push: true
-        tags: ${{ steps.meta.outputs.tags }}
+      run: |
+        docker push --all-tags ${{ inputs.images }}
+      shell: bash

--- a/action.yml
+++ b/action.yml
@@ -3,6 +3,8 @@ name: MCVS-docker-action
 description: |
   Mission Critical Vulnerability Scanner (MCVS) Docker action.
 inputs:
+  build-args:
+    description: Docker build arguments.
   dockle-accept-key:
     description: |
       One of the Dockle checks is the inspection of use of secrets in
@@ -11,6 +13,9 @@ inputs:
       will be installed then an error will be thrown by Dockle, which is
       incorrect. To mitigate this one has to specify the packages that are
       applicable, e.g.: `libcrypto3,libssl3`.
+  images:
+    description: The name of the to be created image.
+    default: ghcr.io/${{ github.repository }}
   trivy-action-db:
     default: "public.ecr.aws/aquasecurity/trivy-db:2"
     description: |
@@ -50,17 +55,18 @@ runs:
       with:
         flavor: |
           latest=false
-        images: ghcr.io/${{ github.repository }}
+        images: ${{ inputs.images }}
     #
     # Build a docker image.
     #
     - name: Build an image from a dockerfile
       uses: docker/build-push-action@v6.9.0
       with:
+        build-args: APPLICATION=${{ inputs.build-args }}
         context: .
+        labels: ${{ steps.meta.outputs.labels }}
         push: false
         tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
     #
     # Docker image linting (dynamic).
     #
@@ -134,7 +140,8 @@ runs:
       if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v6.9.0
       with:
+        build-args: APPLICATION=${{ inputs.build-args }}
         context: .
+        labels: ${{ steps.meta.outputs.labels }}
         push: true
         tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This pull request includes updates to the `action.yml` file for the MCVS Docker action, focusing on adding new input parameters and modifying existing ones to improve flexibility and functionality.

Key changes include:

* **New Input Parameters:**
  * Added `build-args` input for specifying Docker build arguments.
  * Added `images` input for specifying the name of the image to be created, with a default value set to `ghcr.io/${{ github.repository }}`.

* **Modifications in Docker Build Process:**
  * Updated the `images` parameter in the build steps to use the new `inputs.images` value.
  * Included `build-args` and `labels` in the Docker build steps to use the new `inputs.build-args` and `steps.meta.outputs.labels` values. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L53-L63) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R143-L140)