### PR TITLE
build: [#45] Reenable dockle as running bug has been resolved

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,10 @@ description: |
 inputs:
   build-args:
     description: Docker build arguments.
+  context:
+    default: "."
+    description: |
+      Directory path that contains all the files needed to build a Docker image
   dockle-accept-key:
     description: |
       One of the Dockle checks is the inspection of use of secrets in
@@ -30,10 +34,6 @@ inputs:
       image that it has been built, to the packages repository of the GitHub
       repository where the action has been run.
     required: true
-  context:
-    default: "."
-    description: |
-      Directory path that contains all the files needed to build a Docker image
 runs:
   using: "composite"
   steps:
@@ -75,7 +75,6 @@ runs:
     # Docker image linting (dynamic).
     #
     - uses: goodwithtech/dockle-action@v0.4.15
-      if: "false" # Disabled until the bug (#45) is fixed.
       with:
         image: ${{ steps.meta.outputs.tags }}
         ignore: CIS-DI-0005,CIS-DI-0006

--- a/action.yml
+++ b/action.yml
@@ -77,6 +77,11 @@ runs:
     - uses: goodwithtech/dockle-action@v0.4.15
       with:
         image: ${{ steps.meta.outputs.tags }}
+        # CIS-DI-0005: Enable Content trust for Docker as this cannot be
+        # achieved in public GitHub runners.
+        # CIS-DI-0006: Add HEALTHCHECK instruction to the container image as
+        # the decision was made that this is up to the consumer of this action
+        # to set a health check or not.
         ignore: CIS-DI-0005,CIS-DI-0006
         accept-key: ${{ inputs.dockle-accept-key }}
     #


### PR DESCRIPTION
* Ensure that inputs are sorted.
* Reenable dockle as bug that prevented it to run properly has been resolved.
* Rationale for disabling CIS-DI-0005 and CIS-DI-0006.