### PR TITLE
fix: Ensure hadolint fails on error

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,6 +50,7 @@ runs:
     - uses: hadolint/hadolint-action@v3.1.0
       with:
         dockerfile: ${{ inputs.context }}/Dockerfile
+        failure-threshold: style
     #
     # Determine image name and tag.
     #


### PR DESCRIPTION
Ensure that pipeline fails on style issues as well, like DL3048 style: Invalid label key.