### PR TITLE
build: [#46] Reenable Dive after docker runner fix

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -83,10 +83,9 @@ runs:
     #
     # Detect waste in the docker image.
     #
-    - uses: 030/dive-action@v0.1.1
-      if: "false" # Disabled until the bug (#46) is fixed.
+    - uses: docker://wagoodman/dive:v0.12.0
       with:
-        image: ${{ steps.meta.outputs.tags }}
+        args: ${{ steps.meta.outputs.tags }} --ci
     #
     # Code and docker image security scanning.
     #


### PR DESCRIPTION
According to the indirectly linked issue the problem in dive has been resolved and can be reenabled again.