### PR TITLE
fix: Ensure that grype version can be updated as the current default contains high vulnerabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ jobs:
 | build-args           |         |          |
 | context              | x       |          |
 | dockle-accept-key    | x       |          |
+| grype-version        | x       |          |
 | images               | x       |          |
 | token                | x       | x        |
 | trivy-action-db      | x       |          |

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,9 @@ inputs:
       will be installed then an error will be thrown by Dockle, which is
       incorrect. To mitigate this one has to specify the packages that are
       applicable, e.g.: `libcrypto3,libssl3`.
+  grype-version:
+    default: v0.90.0
+    description: The grype version to be used by the anchore/scan-action.
   images:
     description: The name of the to be created image.
     default: ghcr.io/${{ github.repository }}
@@ -96,6 +99,7 @@ runs:
     #
     - uses: anchore/scan-action@v6.1.0
       with:
+        grype-version: ${{ inputs.grype-version }}
         only-fixed: false
         output-format: table
         path: ${{ inputs.context }}
@@ -103,6 +107,7 @@ runs:
     - name: Scan image using Grype
       uses: anchore/scan-action@v6.1.0
       with:
+        grype-version: ${{ inputs.grype-version }}
         image: ${{ steps.meta.outputs.tags }}
         only-fixed: false
         output-format: table


### PR DESCRIPTION
* The current grype v0.87.0 contains high findings. Update it to remediate the issues.