### PR TITLE
fix: Remove commit lint action as it caused too many issues

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,6 @@ runs:
         pip install --user yamllint==1.35.1
         yamllint .
       shell: bash
-    - uses: wagoid/commitlint-github-action@v6.2.1
     #
     # Dockerfile linting (static).
     #


### PR DESCRIPTION
Commit lint will be run only in the [MCVS-golang-action](https://github.com/schubergphilis/mcvs-golang-action/pull/241) to ensure that config can be managed in one place.