### PR TITLE
feat: Extend build args to support more arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@ permissions:
   packages: write
 jobs:
   mcvs-docker-action:
+    strategy:
+        matrix:
+          include:
+            - name: scanner
+              build_args:
+                APPLICATION: my-scanner
+                APPLICATION_PERMISSIONS: 0700
+            - name: analyzer
+              build_args:
+                APPLICATION: my-analyzer
+                APPLICATION_PERMISSIONS: 0755
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4.1.1
@@ -33,6 +44,9 @@ jobs:
         with:
           dockle-accept-key: libcrypto3,libssl3
           token: ${{ secrets.GITHUB_TOKEN }}
+          build-args: |
+            APPLICATION=${{ matrix.build_args.APPLICATION }}
+            APPLICATION_PERMISSIONS=${{ matrix.build_args.APPLICATION_PERMISSIONS }}
 ```
 
 | Option               | Default | Required |

--- a/action.yml
+++ b/action.yml
@@ -3,6 +3,9 @@ name: MCVS-docker-action
 description: |
   Mission Critical Vulnerability Scanner (MCVS) Docker action.
 inputs:
+  application:
+    default: mcvs-scanner
+    description: The name of the application that is being built.
   build-args:
     description: Docker build arguments.
   context:
@@ -69,7 +72,7 @@ runs:
     - name: Build an image from a dockerfile
       uses: docker/build-push-action@v6.18.0
       with:
-        build-args: APPLICATION=${{ inputs.build-args }}
+        build-args: ${{ inputs.build-args }} APPLICATION=${{ inputs.application }}
         context: ${{ inputs.context }}
         labels: ${{ steps.meta.outputs.labels }}
         push: false

--- a/action.yml
+++ b/action.yml
@@ -72,7 +72,7 @@ runs:
     - name: Build an image from a dockerfile
       uses: docker/build-push-action@v6.18.0
       with:
-        build-args: ${{ inputs.build-args }} APPLICATION=${{ inputs.application }}
+        build-args: ${{ inputs.build-args }}
         context: ${{ inputs.context }}
         labels: ${{ steps.meta.outputs.labels }}
         push: false

--- a/action.yml
+++ b/action.yml
@@ -72,7 +72,8 @@ runs:
     - name: Build an image from a dockerfile
       uses: docker/build-push-action@v6.18.0
       with:
-        build-args: ${{ inputs.build-args }}
+        build-args: |-
+          ${{ inputs.build-args }}
         context: ${{ inputs.context }}
         labels: ${{ steps.meta.outputs.labels }}
         push: false


### PR DESCRIPTION
# What & Why??

Extended the build-args to support more arguments, because it only supported the APPLICATION arg so far

This has been tested in the following run

https://github.com/schubergphilis/mcvs-scanner/actions/runs/15754660798