### PR TITLE
fix: move yamllint to general action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,13 +42,6 @@ runs:
   using: "composite"
   steps:
     #
-    # linting.
-    #
-    - run: |
-        pip install --user yamllint==1.35.1
-        yamllint .
-      shell: bash
-    #
     # Dockerfile linting (static).
     #
     - uses: hadolint/hadolint-action@v3.1.0


### PR DESCRIPTION
Move YAMLLint to the [MCVS-general-action](https://github.com/schubergphilis/mcvs-general-action/pull/8) as it is a general action.