### PR TITLE
fix: use grype hash

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -114,7 +114,7 @@ runs:
     #
     # Code and docker image security scanning.
     #
-    - uses: anchore/scan-action@v7.4.0
+    - uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
       with:
         grype-version: ${{ inputs.grype-version }}
         only-fixed: false
@@ -122,7 +122,7 @@ runs:
         path: ${{ inputs.context }}
         severity-cutoff: high
     - name: Scan image using Grype
-      uses: anchore/scan-action@v7.4.0
+      uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
       with:
         grype-version: ${{ inputs.grype-version }}
         image: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
To prevent that a version will be used that will be overwritten.