### PR TITLE
fix: dive-ci to adjust thresholds if needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,23 @@ This action employs a defense-in-depth approach with multiple security scanners:
   - Severity cutoff: HIGH
   - Reports unfixed vulnerabilities
 
+### Dive Efficiency Analysis
+
+- Analyzes image layers for wasted space
+- Runs in CI mode (`--ci`) and reads thresholds from a `.dive-ci` file in your
+  repository root when present
+- Example `.dive-ci` configuration:
+
+```yaml
+rules:
+  lowestEfficiency: 0.95
+  highestWastedBytes: 20MB
+  highestUserWastedPercent: 0.20
+```
+
+See the [Dive CI documentation](https://github.com/wagoodman/dive#ci-integration)
+for all available options.
+
 ### Dockle Linting
 
 - Validates CIS Docker benchmarks

--- a/action.yml
+++ b/action.yml
@@ -110,7 +110,7 @@ runs:
     #
     - uses: docker://wagoodman/dive:v0.13.1@sha256:f1886e6c32c094fc41a623c1989f5cb3e48aa766da5f0be233f911fc1d85ce10
       with:
-        args: ${{ steps.meta.outputs.tags }} --ci
+        args: ${{ steps.meta.outputs.tags }} --ci --ci-config .dive-ci
     #
     # Code and docker image security scanning.
     #


### PR DESCRIPTION
Sometimes it is not possible to make an image leaner. Therefor thresholds have to be adjusted.